### PR TITLE
Escrow as described in #12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	compile('org.ethereum:ethereumj-core:1.3.1-RELEASE') {
 		exclude group: "org.slf4j", module: "slf4j-log4j12"
 	}
+	compile('org.json:json:20090211')
+	compile('commons-io:commons-io:2.5')
 	compile('org.apache.httpcomponents:httpclient')
 	compile('org.projectlombok:lombok:1.16.6')
 	compile('org.flywaydb:flyway-core:4.0.1')

--- a/src/main/java/com/kryptoeuro/accountmapper/EscrowRepository.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/EscrowRepository.java
@@ -1,0 +1,14 @@
+package com.kryptoeuro.accountmapper;
+
+import com.kryptoeuro.accountmapper.domain.Escrow;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface EscrowRepository extends CrudRepository<Escrow,Long> {
+
+    List<Escrow> findByIdCode(Long idCode);
+    List<Escrow> findByIdCodeAndCleared(Long idCode, boolean cleared);
+
+    void delete(Long id);
+}

--- a/src/main/java/com/kryptoeuro/accountmapper/EthereumAccountRepository.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/EthereumAccountRepository.java
@@ -1,6 +1,7 @@
 package com.kryptoeuro.accountmapper;
 
 import com.kryptoeuro.accountmapper.domain.EthereumAccount;
+import com.kryptoeuro.accountmapper.domain.AuthorisationType;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
@@ -12,6 +13,8 @@ public interface EthereumAccountRepository extends CrudRepository<EthereumAccoun
 
     List<EthereumAccount> findByAddressAndActivated(String accountAddress, boolean activated);
     List<EthereumAccount> findByOwnerIdAndActivated(String accountAddress, boolean activated);
+    List<EthereumAccount> findByOwnerIdAndAuthorisationTypeNot(String accountAddress, AuthorisationType authType);
+    List<EthereumAccount> findByOwnerIdAndActivatedAndAuthorisationTypeNot(String accountAddress, boolean activated, AuthorisationType authType);
     List<EthereumAccount> findAll();
 
     void delete(Long id);

--- a/src/main/java/com/kryptoeuro/accountmapper/EthereumAccountRepository.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/EthereumAccountRepository.java
@@ -11,6 +11,7 @@ public interface EthereumAccountRepository extends CrudRepository<EthereumAccoun
     List<EthereumAccount> findByAddress(String accountAddress);
 
     List<EthereumAccount> findByAddressAndActivated(String accountAddress, boolean activated);
+    List<EthereumAccount> findByOwnerIdAndActivated(String accountAddress, boolean activated);
     List<EthereumAccount> findAll();
 
     void delete(Long id);

--- a/src/main/java/com/kryptoeuro/accountmapper/domain/AuthorisationType.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/domain/AuthorisationType.java
@@ -3,5 +3,6 @@ package com.kryptoeuro.accountmapper.domain;
 public enum AuthorisationType {
 	MOBILE_ID,
 	ID_CARD,
+	ESCROW,
 	BANK_TRANSFER
 }

--- a/src/main/java/com/kryptoeuro/accountmapper/domain/Escrow.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/domain/Escrow.java
@@ -1,0 +1,27 @@
+package com.kryptoeuro.accountmapper.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Escrow {
+    @Id @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    private Long idCode;
+    private String address;
+    private String privateKey;
+
+    // set to true after being cleared
+    private boolean cleared = false;
+    // hash of the clearing transaction 
+    private String clearingHash;
+}

--- a/src/main/java/com/kryptoeuro/accountmapper/error/HasActiveAccountException.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/error/HasActiveAccountException.java
@@ -1,0 +1,8 @@
+package com.kryptoeuro.accountmapper.error;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value=HttpStatus.FORBIDDEN, reason="This ID code already has associated active address.")
+public class HasActiveAccountException extends RuntimeException {
+}

--- a/src/main/java/com/kryptoeuro/accountmapper/response/AccountActivationResponse.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/response/AccountActivationResponse.java
@@ -2,8 +2,10 @@ package com.kryptoeuro.accountmapper.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.kryptoeuro.accountmapper.domain.AuthorisationType;
+import com.kryptoeuro.accountmapper.response.EscrowTransfer;
 import lombok.Builder;
 import lombok.Data;
+import java.util.List;
 
 @Data
 @Builder
@@ -14,6 +16,7 @@ public class AccountActivationResponse {
 	String transactionHash;
 	String address;
 	String ownerId;
+	List<EscrowTransfer> escrowTransfers;
 
 	public static AccountActivationResponseBuilder getBuilderForAuthType(AuthorisationType authType) {
 		return AccountActivationResponse.builder().authorisationType(authType.name());

--- a/src/main/java/com/kryptoeuro/accountmapper/response/AccountActivationResponse.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/response/AccountActivationResponse.java
@@ -12,6 +12,7 @@ public class AccountActivationResponse {
 	String authenticationStatus;
 	String authorisationType;
 	String transactionHash;
+	String address;
 	String ownerId;
 
 	public static AccountActivationResponseBuilder getBuilderForAuthType(AuthorisationType authType) {

--- a/src/main/java/com/kryptoeuro/accountmapper/response/EscrowTransfer.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/response/EscrowTransfer.java
@@ -1,0 +1,17 @@
+package com.kryptoeuro.accountmapper.response;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import java.util.Date;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EscrowTransfer {
+	private Long amount;
+	private String transactionHash;
+	private Long timestamp = new Long(new Date().getTime());
+}

--- a/src/main/java/com/kryptoeuro/accountmapper/response/WalletServerAccountResponse.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/response/WalletServerAccountResponse.java
@@ -1,0 +1,19 @@
+package com.kryptoeuro.accountmapper.response;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WalletServerAccountResponse {
+	private String address;
+	private boolean approved;
+	private boolean closed;
+	private boolean frozen;
+	private long nonce;
+	private long balance;
+}

--- a/src/main/java/com/kryptoeuro/accountmapper/response/WalletServerHistoryResponse.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/response/WalletServerHistoryResponse.java
@@ -1,0 +1,20 @@
+package com.kryptoeuro.accountmapper.response;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class WalletServerHistoryResponse {
+	private String id;
+	private String targetAccount;
+	private String sourceAccount;
+	private long amount;
+	private long timestamp;
+}

--- a/src/main/java/com/kryptoeuro/accountmapper/rest/AccountMapperController.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/rest/AccountMapperController.java
@@ -8,6 +8,7 @@ import com.kryptoeuro.accountmapper.command.PollCommand;
 import com.kryptoeuro.accountmapper.domain.AuthorisationType;
 import com.kryptoeuro.accountmapper.domain.EthereumAccount;
 import com.kryptoeuro.accountmapper.domain.PendingAuthorisation;
+import com.kryptoeuro.accountmapper.response.EscrowTransfer;
 import com.kryptoeuro.accountmapper.response.AccountsResponse;
 import com.kryptoeuro.accountmapper.response.AuthenticateResponse;
 import com.kryptoeuro.accountmapper.response.AccountActivationResponse;
@@ -30,6 +31,7 @@ import java.io.IOException;
 import java.security.Principal;
 import java.util.Base64;
 import java.util.List;
+import java.util.ArrayList;
 
 import static org.springframework.web.bind.annotation.RequestMethod.*;
 
@@ -42,6 +44,8 @@ public class AccountMapperController {
 	MobileIdAuthService mobileIdAuthService;
 	@Autowired
 	EthereumService ethereumService;
+	@Autowired
+	EscrowService escrowService;
 	@Autowired
 	AccountManagementService accountManagementService;
 	@Autowired
@@ -246,6 +250,8 @@ public class AccountMapperController {
 		accountManagementService.removeAccountById(mappingId);
 		return new ResponseEntity<AccountsResponse>(AccountsResponse.fromEthereumAccounts(accountManagementService.getAllAccounts()), HttpStatus.OK);
 	}
+
+
 
 
 }

--- a/src/main/java/com/kryptoeuro/accountmapper/rest/AccountMapperController.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/rest/AccountMapperController.java
@@ -272,32 +272,6 @@ public class AccountMapperController {
 	}
 
 
-	//TODO: REMOVE THIS, ONLY HERE FOR TESTING ESCROW
-
-	@ApiOperation(value = "TEST-TEST-TEST authorises any id code as ID CARD")
-	@RequestMapping(
-			method = GET,
-			value = "/authorisations/testActivate/{ownerId}/{address}")
-	public ResponseEntity<AccountActivationResponse> testActivate(@PathVariable(value="ownerId") String ownerId, @PathVariable(value="address") String address) throws  IOException {
-
-		walletService.getHistory("0x833898875a12a3d61ef18dc3d2b475c7ca3a4a72");
-		//ethereumService.testSigning();
-		/*
-		EthereumAccount account = accountManagementService.storeNewAccount(address, ownerId, AuthorisationType.ID_CARD);
-		String txHash = ethereumService.activateEthereumAccount(account.getAddress());
-
-		accountManagementService.markActivated(account,txHash);
-		//accountManagementService.markActivated(account,null);
-		AccountActivationResponse response = AccountActivationResponse.builder()
-				.authenticationStatus(AuthenticationStatus.LOGIN_SUCCESS.name())
-				.ownerId(ownerId)
-				.transactionHash(txHash)
-				.build();
-
-	  	response.setEscrowTransfers(clearEscrow(account));
-		*/
-		return new ResponseEntity<>(null, HttpStatus.OK);
-	}
 
 
 

--- a/src/main/java/com/kryptoeuro/accountmapper/rest/EscrowController.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/rest/EscrowController.java
@@ -1,0 +1,55 @@
+package com.kryptoeuro.accountmapper.rest;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.beans.factory.annotation.Autowired;
+import io.swagger.annotations.ApiOperation;
+import lombok.extern.slf4j.Slf4j;
+import javax.validation.Valid;
+
+import com.kryptoeuro.accountmapper.error.LdapNotFoundException;
+import com.kryptoeuro.accountmapper.error.HasActiveAccountException;
+
+import com.kryptoeuro.accountmapper.domain.EthereumAccount;
+import com.kryptoeuro.accountmapper.state.AuthenticationStatus;
+import com.kryptoeuro.accountmapper.response.AccountActivationResponse;
+import com.kryptoeuro.accountmapper.service.EscrowService;
+import com.kryptoeuro.accountmapper.service.LdapService;
+import com.kryptoeuro.accountmapper.service.AccountManagementService;
+
+@RestController
+@RequestMapping("/v1/escrow")
+@Slf4j
+@CrossOrigin(origins = "*")
+public class EscrowController {
+
+	@Autowired
+	EscrowService escrowService;
+	@Autowired
+	LdapService ldapService;
+	@Autowired
+	AccountManagementService accountService;
+
+
+	@RequestMapping(method = RequestMethod.GET, value = "/{idCode}")
+	public ResponseEntity<AccountActivationResponse> getEscrow(@PathVariable("idCode") @Valid long idCode) {
+		if (accountService.hasActivatedAccount(idCode)) { throw new HasActiveAccountException(); };
+		if (ldapService.lookupIdCode(idCode) == null) { throw new LdapNotFoundException(); };
+
+		EthereumAccount account = escrowService.approveEscrowAccountForId(idCode);
+		AccountActivationResponse aaResponse = AccountActivationResponse.builder()
+						.authenticationStatus(AuthenticationStatus.LOGIN_SUCCESS.name())
+						.ownerId(account.getOwnerId())
+						.address(account.getAddress())
+						.transactionHash(account.getTransactionHash())
+						.build();
+		return new ResponseEntity<AccountActivationResponse>(aaResponse, HttpStatus.OK);
+	}
+}

--- a/src/main/java/com/kryptoeuro/accountmapper/rest/EscrowController.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/rest/EscrowController.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import io.swagger.annotations.ApiOperation;
 import lombok.extern.slf4j.Slf4j;
 import javax.validation.Valid;
+import java.io.IOException;
 
 import com.kryptoeuro.accountmapper.error.LdapNotFoundException;
 import com.kryptoeuro.accountmapper.error.HasActiveAccountException;
@@ -43,7 +44,14 @@ public class EscrowController {
 		if (accountService.hasActivatedAccount(idCode)) { throw new HasActiveAccountException(); };
 		if (ldapService.lookupIdCode(idCode) == null) { throw new LdapNotFoundException(); };
 
-		EthereumAccount account = escrowService.approveEscrowAccountForId(idCode);
+		EthereumAccount account;
+
+		try {
+			account = escrowService.approveEscrowAccountForId(idCode);
+		} catch (IOException  e) {
+			throw new RuntimeException("IO issue when approving address",e.getCause());
+		}
+
 		AccountActivationResponse aaResponse = AccountActivationResponse.builder()
 						.authenticationStatus(AuthenticationStatus.LOGIN_SUCCESS.name())
 						.ownerId(account.getOwnerId())

--- a/src/main/java/com/kryptoeuro/accountmapper/rest/EscrowController.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/rest/EscrowController.java
@@ -40,17 +40,13 @@ public class EscrowController {
 
 
 	@RequestMapping(method = RequestMethod.GET, value = "/{idCode}")
-	public ResponseEntity<AccountActivationResponse> getEscrow(@PathVariable("idCode") @Valid long idCode) {
+	public ResponseEntity<AccountActivationResponse> getEscrow(@PathVariable("idCode") @Valid long idCode) throws IOException {
 		if (accountService.hasActivatedAccount(idCode)) { throw new HasActiveAccountException(); };
 		if (ldapService.lookupIdCode(idCode) == null) { throw new LdapNotFoundException(); };
 
 		EthereumAccount account;
 
-		try {
-			account = escrowService.approveEscrowAccountForId(idCode);
-		} catch (IOException  e) {
-			throw new RuntimeException("IO issue when approving address",e.getCause());
-		}
+		account = escrowService.approveEscrowAccountForId(idCode);
 
 		AccountActivationResponse aaResponse = AccountActivationResponse.builder()
 						.authenticationStatus(AuthenticationStatus.LOGIN_SUCCESS.name())

--- a/src/main/java/com/kryptoeuro/accountmapper/security/EncryptionUtils.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/security/EncryptionUtils.java
@@ -1,0 +1,88 @@
+package com.kryptoeuro.accountmapper.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+ 
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+ 
+@Service
+@Slf4j
+public class EncryptionUtils {
+ 
+    // this is AES
+    private SecretKeySpec secretKey;
+    private byte[] key;
+
+    @Value("${escrow.encryption.password}")
+    private String configKey;
+ 
+    public void setKey(String myKey) 
+    {
+        MessageDigest sha = null;
+        try {
+            key = myKey.getBytes("UTF-8");
+            sha = MessageDigest.getInstance("SHA-1");
+            key = sha.digest(key);
+            key = Arrays.copyOf(key, 16); 
+            secretKey = new SecretKeySpec(key, "AES");
+        } 
+        catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        } 
+        catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+    }
+ 
+    public String encrypt(String strToEncrypt) 
+    {
+	log.info("just checking encryption key " + configKey);
+	return encrypt(strToEncrypt,configKey);
+    }
+    
+    public String decrypt(String strToDecrypt) 
+    {
+	return decrypt(strToDecrypt,configKey);
+    }
+    
+    public String encrypt(String strToEncrypt, String secret) 
+    {
+        try
+        {
+            setKey(secret);
+            Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+            return Base64.getEncoder().encodeToString(cipher.doFinal(strToEncrypt.getBytes("UTF-8")));
+        } 
+        catch (Exception e) 
+        {
+            System.out.println("Error while encrypting: " + e.toString());
+        }
+        return null;
+    }
+ 
+    public String decrypt(String strToDecrypt, String secret) 
+    {
+        try
+        {
+            setKey(secret);
+            Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5PADDING");
+            cipher.init(Cipher.DECRYPT_MODE, secretKey);
+            return new String(cipher.doFinal(Base64.getDecoder().decode(strToDecrypt)));
+        } 
+        catch (Exception e) 
+        {
+            System.out.println("Error while decrypting: " + e.toString());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/kryptoeuro/accountmapper/service/AccountManagementService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/AccountManagementService.java
@@ -21,8 +21,11 @@ public class AccountManagementService {
 	EthereumAccountRepository ethereumAccountRepository;
 	@Autowired
 	EscrowService escrowService;
+	@Autowired
+	EthereumService ethService;
 
 	public EthereumAccount storeNewAccount(String address, String ownerId, AuthorisationType authorisationType) {
+		address = ethService.without0x(address);
 		try {
 			validateAccountStoring(address, ownerId);
 			EthereumAccount account = EthereumAccount.builder()

--- a/src/main/java/com/kryptoeuro/accountmapper/service/AccountManagementService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/AccountManagementService.java
@@ -69,8 +69,17 @@ public class AccountManagementService {
 		return !approvedList.isEmpty();
 	}
 
-	public List<EthereumAccount> getAccountsByOwnerId(String ownerId) {
-		return ethereumAccountRepository.findByOwnerId(ownerId);
+	public List<EthereumAccount> getAccountsByOwnerIdActiveEscrow(String ownerId,boolean inactive, boolean escrow) {
+		if (inactive && escrow) {
+			return ethereumAccountRepository.findByOwnerId(ownerId);
+		} else if (escrow) {
+			return ethereumAccountRepository.findByOwnerIdAndActivated(ownerId,true);
+		} else if (inactive) {
+			return ethereumAccountRepository.findByOwnerIdAndAuthorisationTypeNot(ownerId,AuthorisationType.ESCROW);
+		} else {
+			return ethereumAccountRepository.findByOwnerIdAndActivatedAndAuthorisationTypeNot(ownerId,true,AuthorisationType.ESCROW);
+		}
+		
 	}
 
 	public List<EthereumAccount> getAccountsByAccountAddress(String accountAddress) {

--- a/src/main/java/com/kryptoeuro/accountmapper/service/AccountManagementService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/AccountManagementService.java
@@ -57,6 +57,14 @@ public class AccountManagementService {
 
 	}
 
+	public boolean hasActivatedAccount(long ownerId) { return hasActivatedAccount(String.valueOf(ownerId)); }
+	public boolean hasActivatedAccount(String ownerId) {
+		
+		List<EthereumAccount> approvedList = ethereumAccountRepository.findByOwnerIdAndActivated(ownerId,true);
+		log.info("checked repo for " +ownerId+ " accounts and found "+String.valueOf(approvedList.size()));
+		return !approvedList.isEmpty();
+	}
+
 	public List<EthereumAccount> getAccountsByOwnerId(String ownerId) {
 		return ethereumAccountRepository.findByOwnerId(ownerId);
 	}

--- a/src/main/java/com/kryptoeuro/accountmapper/service/AccountManagementService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/AccountManagementService.java
@@ -100,4 +100,14 @@ public class AccountManagementService {
 	public void removeAccountById(Long id) {
 		ethereumAccountRepository.delete(id);
 	}
+
+
+	public void deactivateAddress(String address) {
+		//eg when clearing escrow
+		List<EthereumAccount> accounts = getAccountsByAccountAddress(ethService.without0x(address));
+		accounts.forEach((acc) -> {
+			acc.setActivated(false);
+			ethereumAccountRepository.save(acc);
+		});
+	}
 }

--- a/src/main/java/com/kryptoeuro/accountmapper/service/AccountManagementService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/AccountManagementService.java
@@ -19,6 +19,8 @@ public class AccountManagementService {
 
 	@Autowired
 	EthereumAccountRepository ethereumAccountRepository;
+	@Autowired
+	EscrowService escrowService;
 
 	public EthereumAccount storeNewAccount(String address, String ownerId, AuthorisationType authorisationType) {
 		try {
@@ -42,7 +44,9 @@ public class AccountManagementService {
 		try {
 			account.setActivated(true);
 			account.setTransactionHash(txHash);
+
 			ethereumAccountRepository.save(account);
+			
 		} catch (Exception e) {
 			throw new CannotStoreAccountException("Crashed while activating new account", e.getCause());
 		}

--- a/src/main/java/com/kryptoeuro/accountmapper/service/EscrowService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/EscrowService.java
@@ -1,0 +1,55 @@
+package com.kryptoeuro.accountmapper.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.ethereum.crypto.ECKey;
+
+import com.kryptoeuro.accountmapper.domain.Escrow;
+import com.kryptoeuro.accountmapper.domain.EthereumAccount;
+import com.kryptoeuro.accountmapper.domain.AuthorisationType;
+import com.kryptoeuro.accountmapper.response.AccountActivationResponse;
+import com.kryptoeuro.accountmapper.EscrowRepository;
+import com.kryptoeuro.accountmapper.security.EncryptionUtils;
+
+import java.util.List;
+
+@Service
+@Slf4j
+public class EscrowService {
+
+	@Autowired
+	AccountManagementService accountService;
+	@Autowired
+	EthereumService ethereumService;
+	@Autowired
+	EscrowRepository escrowRepository;
+	@Autowired
+	EncryptionUtils encUtils;
+
+	private Escrow getExistingEscrow(long idCode) {
+		List<Escrow> escrowList = escrowRepository.findByIdCodeAndCleared(Long.valueOf(idCode),false);
+		return (escrowList.isEmpty()) ? null : escrowList.get(0);
+        }
+
+	public Escrow createEscrowKey(long idCode) {
+		ECKey key = new ECKey();	
+		Escrow escrow = Escrow.builder()
+				.privateKey(encUtils.encrypt(ethereumService.hex(key.getPrivKeyBytes())))
+				.address(ethereumService.hex(key.getAddress()))
+				.idCode(idCode)
+				.build();
+
+		return escrow;
+	};
+
+	public EthereumAccount approveEscrowAccountForId(long idCode) {
+		Escrow escrow = createEscrowKey(idCode);
+		EthereumAccount ethAccount = accountService.storeNewAccount(escrow.getAddress(), String.valueOf(escrow.getIdCode()), AuthorisationType.ESCROW);
+		String txHash = activateEthereumAccount(escrow.address);
+		//String txHash = new String("0x123456-stub");
+		accountService.markActivated(ethAccount, txHash);
+		escrowRepository.save(escrow);
+		return ethAccount;
+	}
+}

--- a/src/main/java/com/kryptoeuro/accountmapper/service/EscrowService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/EscrowService.java
@@ -54,7 +54,6 @@ public class EscrowService {
 		Escrow escrow = createEscrowKey(idCode);
 		EthereumAccount ethAccount = accountService.storeNewAccount(escrow.getAddress(), String.valueOf(escrow.getIdCode()), AuthorisationType.ESCROW);
 		String txHash = ethereumService.activateEthereumAccount(escrow.getAddress());
-		//String txHash = new String("0x123456-stub");
 		accountService.markActivated(ethAccount, txHash);
 		escrowRepository.save(escrow);
 		return ethAccount;

--- a/src/main/java/com/kryptoeuro/accountmapper/service/EscrowService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/EscrowService.java
@@ -78,7 +78,6 @@ public class EscrowService {
 			}
 			escrow.setCleared(true);
 			escrowRepository.save(escrow);
-			// here should copy references over too
 		}
 		return etxs;
 	}
@@ -86,6 +85,7 @@ public class EscrowService {
 
 		WalletServerAccountResponse addrDetails = wsService.getAccount(escrow.getAddress()); 
 		List<WalletServerHistoryResponse> history = wsService.getHistory(escrow.getAddress()); 
+		accountService.deactivateAddress(escrow.getAddress());
 		long bal = addrDetails.getBalance();
 		if (bal > 0) {
 			log.info("Move total of: "+String.valueOf(addrDetails.getBalance())+" to "+ address + " sign with " + encUtils.decrypt(escrow.getPrivateKey()));

--- a/src/main/java/com/kryptoeuro/accountmapper/service/EscrowService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/EscrowService.java
@@ -12,8 +12,12 @@ import com.kryptoeuro.accountmapper.domain.AuthorisationType;
 import com.kryptoeuro.accountmapper.response.AccountActivationResponse;
 import com.kryptoeuro.accountmapper.EscrowRepository;
 import com.kryptoeuro.accountmapper.security.EncryptionUtils;
+import com.kryptoeuro.accountmapper.response.WalletServerAccountResponse;
+import com.kryptoeuro.accountmapper.response.EscrowTransfer;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Date;
 
 @Service
 @Slf4j
@@ -27,8 +31,10 @@ public class EscrowService {
 	EscrowRepository escrowRepository;
 	@Autowired
 	EncryptionUtils encUtils;
+	@Autowired
+	WalletServerService wsService;
 
-	private Escrow getExistingEscrow(long idCode) {
+	public Escrow getExistingEscrow(long idCode) {
 		List<Escrow> escrowList = escrowRepository.findByIdCodeAndCleared(Long.valueOf(idCode),false);
 		return (escrowList.isEmpty()) ? null : escrowList.get(0);
         }
@@ -52,5 +58,45 @@ public class EscrowService {
 		accountService.markActivated(ethAccount, txHash);
 		escrowRepository.save(escrow);
 		return ethAccount;
+	}
+	public  List<EscrowTransfer> clearAllToAddress(long idCode, String address) throws IOException {
+		Escrow escrow;
+		List<EscrowTransfer> etxs = new ArrayList<EscrowTransfer>();
+
+		// Need to wait until the new account approval has been mined
+		// doesn't work for multiple, because of eth nonce - need to create queue
+		// assuming that this is always called  after Account Approval tx
+		int nonceIncrement = 1;
+
+		while ( (escrow = getExistingEscrow(idCode)) != null) {
+			EscrowTransfer transfer = clearToAddress(escrow, address,nonceIncrement);
+			if (transfer != null) {
+				nonceIncrement++;
+				etxs.add(transfer);
+				escrow.setClearingHash(transfer.getTransactionHash());
+			}
+			escrow.setCleared(true);
+			escrowRepository.save(escrow);
+			// here should copy references over too
+		}
+		return etxs;
+	}
+	public EscrowTransfer clearToAddress(Escrow escrow, String address, int nonceIncrement) throws IOException {
+
+		WalletServerAccountResponse addrDetails = wsService.getAccount(escrow.getAddress()); 
+		long bal = addrDetails.getBalance();
+		if (bal > 0) {
+			log.info("Move "+String.valueOf(addrDetails.getBalance())+" to "+ address + " sign with " + encUtils.decrypt(escrow.getPrivateKey()));
+
+			String txHash = ethereumService.sendBalance(address,encUtils.decrypt(escrow.getPrivateKey()), nonceIncrement);
+			EscrowTransfer escrowTransfer = EscrowTransfer.builder()
+				.amount(bal)
+				.transactionHash(txHash)
+				.timestamp(new Date().getTime())
+				.build();
+			return escrowTransfer;
+		} else {
+			return null;
+		}
 	}
 }

--- a/src/main/java/com/kryptoeuro/accountmapper/service/EscrowService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/EscrowService.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.ethereum.crypto.ECKey;
+import java.io.IOException;
 
 import com.kryptoeuro.accountmapper.domain.Escrow;
 import com.kryptoeuro.accountmapper.domain.EthereumAccount;
@@ -43,10 +44,10 @@ public class EscrowService {
 		return escrow;
 	};
 
-	public EthereumAccount approveEscrowAccountForId(long idCode) {
+	public EthereumAccount approveEscrowAccountForId(long idCode) throws IOException {
 		Escrow escrow = createEscrowKey(idCode);
 		EthereumAccount ethAccount = accountService.storeNewAccount(escrow.getAddress(), String.valueOf(escrow.getIdCode()), AuthorisationType.ESCROW);
-		String txHash = activateEthereumAccount(escrow.address);
+		String txHash = ethereumService.activateEthereumAccount(escrow.getAddress());
 		//String txHash = new String("0x123456-stub");
 		accountService.markActivated(ethAccount, txHash);
 		escrowRepository.save(escrow);

--- a/src/main/java/com/kryptoeuro/accountmapper/service/EthereumService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/EthereumService.java
@@ -214,20 +214,28 @@ public class EthereumService {
 		return byteSig;
 	}
 
-
 	public String sendBalance(String toAddress, String privKey, int nonceIncrement) throws IOException {
+
+		
+		ECKey signer = ECKey.fromPrivate(Hex.decode(without0x(privKey)));
+		WalletServerAccountResponse addrDetails = wsService.getAccount(hex(signer.getAddress())); 
+		return sendBalance(toAddress,privKey,nonceIncrement,addrDetails.getBalance());
+	}
+
+	public String sendBalance(String toAddress, String privKey, int nonceIncrement, long amount) throws IOException {
 
 		
 		ECKey signer = ECKey.fromPrivate(Hex.decode(without0x(privKey)));
 		ECKey sponsorKey = getAccountApproverKey(); 
 		
 		WalletServerAccountResponse addrDetails = wsService.getAccount(hex(signer.getAddress())); 
-		byte[] signatureArg = signDelegate(0, addrDetails.getBalance(), addrDetails.getNonce()+1, without0x(toAddress), signer); 
+
+		byte[] signatureArg = signDelegate(0, amount, addrDetails.getNonce()+1, without0x(toAddress), signer); 
 
 		byte[] callData = transferFunction.encode(
 			addrDetails.getNonce()+1, 
 			toAddress, 
-			addrDetails.getBalance(), 
+			amount, 
 			0, 
 			signatureArg, 
 			hex(sponsorKey.getAddress()));

--- a/src/main/java/com/kryptoeuro/accountmapper/service/EthereumService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/EthereumService.java
@@ -12,16 +12,23 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.ethereum.core.CallTransaction.Function;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.ByteUtil;
 import org.spongycastle.util.encoders.Hex;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.io.InputStream;
 import java.util.Scanner;
+import java.io.ByteArrayOutputStream;
+import java.math.BigInteger;
+
+import com.kryptoeuro.accountmapper.response.WalletServerAccountResponse;
 
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.joining;
@@ -31,6 +38,10 @@ import static java.util.stream.Collectors.joining;
 @Transactional(rollbackFor = Exception.class)
 public class EthereumService {
 
+	@Autowired
+	WalletServerService wsService;
+
+
 	private HttpClient httpClient = HttpClientBuilder.create().build();
 
 	//Todo configure in yml
@@ -39,10 +50,12 @@ public class EthereumService {
 //	private String contractAddress = "0xC91F200C33de61FF7B9B930968d0B59C1b86DAf9"; // 2.10.2016 9:56PM
 //	private String contractAddress = "0x76f86A0a55FB69970af5cB691c41F8bb8b722F52"; // 3.10.2016 11:45AM
 	private String contractAddress = "0xA5f9b79Fc7f067Df25A795685493514A295A8A81"; // 3.10.2016 15:14PM
+	private String contractAddressForTransfers = "0xaf71e622792f47119411ce019f4ca1b8d993496e"; // 3.10.2016 15:14PM
 	private String jsonRpcUrl = "http://46.4.80.11:8545"; // Parity node on AWS
 
 	private Function approveAccountFunction = Function.fromSignature("approveAccount", "address");
 	private Function appointAccountApproverFunction = Function.fromSignature("appointAccountApprover", "address");
+	private Function transferFunction = Function.fromSignature("transfer", "uint256", "address", "uint256", "uint256", "bytes", "address");
 
 	public String activateEthereumAccount(String accountAddress) throws IOException {
 		accountAddress = with0x(accountAddress);
@@ -60,7 +73,12 @@ public class EthereumService {
 	}
 
 	private String sendTransaction(ECKey signer, byte[] callData) throws IOException {
-		long transactionCount = getTransactionCount(hex(signer.getAddress()));
+		return sendTransaction(signer, callData, contractAddress, 0);
+	}
+
+	private String sendTransaction(ECKey signer, byte[] callData, String _contract, int  nonceIncrement) throws IOException {
+		//TODO: maybe a queue of pending transactions, otherwise one goes  through at a time
+		long transactionCount = getTransactionCount(hex(signer.getAddress())) + nonceIncrement;
 		long gasPriceLong = getGasPrice();
 		log.info("Current gas price: " + String.valueOf(gasPriceLong));
 		byte[] nonce = ByteUtil.longToBytesNoLeadZeroes(transactionCount);
@@ -69,7 +87,7 @@ public class EthereumService {
 		byte[] gasPrice = ByteUtil.longToBytesNoLeadZeroes(Math.round(gasPriceLong * 1.2));
 		byte[] gasLimit = ByteUtil.longToBytesNoLeadZeroes(200000);
 
-		byte[] toAddress = Hex.decode(without0x(contractAddress));
+		byte[] toAddress = Hex.decode(without0x(_contract));
 
 		Transaction transaction = new Transaction(nonce, gasPrice, gasLimit, toAddress, null, callData);
 		//noinspection ConstantConditions
@@ -160,5 +178,62 @@ public class EthereumService {
 		try (InputStream is = stream) {
 			return new Scanner(is).useDelimiter("\\A").next();
 		}
+	}
+
+	public byte[] uint256(long val) {
+		ByteBuffer bytes = ByteBuffer.allocate(32);
+		bytes.putLong(32-Long.BYTES,val);
+		return bytes.array();
+	}
+
+	public void testSigning() throws IOException {
+		
+		String addr = "65fa6548764c08c0dd77495b33ed302d0c212691";
+
+		ECKey signer = ECKey.fromPrivate(Hex.decode(without0x("0xc33d80b3fddd6bc5d62498905b90c94cf1252ffd846def3b530acd803bbb3783")));
+		signDelegate(0,3,1,"65fa6548764c08c0dd77495b33ed302d0c212691",signer);
+		WalletServerAccountResponse addrDetails = wsService.getAccount(hex(signer.getAddress())); 
+		log.info("some info about address"+ addrDetails.toString());
+	}
+	
+	//TODO: should write unit tests on hash and signature construction
+	public byte[] signDelegate(long fee, long amount, long nonce, String address, ECKey signer) throws IOException {
+		ByteArrayOutputStream hashInput = new ByteArrayOutputStream( );
+		hashInput.write(uint256(nonce));
+		hashInput.write(Hex.decode(without0x(address)));
+		hashInput.write(uint256(amount));
+		hashInput.write(uint256(fee));
+
+		byte[] hashOutput = HashUtil.sha3(hashInput.toByteArray());
+		String strSig = signer.sign(hashOutput).toBase64();
+
+		// Because contract expects the sig concatenated in different order than canonical
+		byte[] byteSig = new byte[65];
+		System.arraycopy(Base64.decodeBase64(strSig),1,byteSig,0,64);
+		System.arraycopy(Base64.decodeBase64(strSig),0,byteSig,64,1);
+		return byteSig;
+	}
+
+
+	public String sendBalance(String toAddress, String privKey, int nonceIncrement) throws IOException {
+
+		
+		ECKey signer = ECKey.fromPrivate(Hex.decode(without0x(privKey)));
+		ECKey sponsorKey = getAccountApproverKey(); 
+		
+		WalletServerAccountResponse addrDetails = wsService.getAccount(hex(signer.getAddress())); 
+		byte[] signatureArg = signDelegate(0, addrDetails.getBalance(), addrDetails.getNonce()+1, without0x(toAddress), signer); 
+
+		byte[] callData = transferFunction.encode(
+			addrDetails.getNonce()+1, 
+			toAddress, 
+			addrDetails.getBalance(), 
+			0, 
+			signatureArg, 
+			hex(sponsorKey.getAddress()));
+	
+		String txHash = sendTransaction(sponsorKey, callData, contractAddressForTransfers, nonceIncrement);
+		log.info("Submitted transfer and got Tx= "+txHash);
+		return txHash;
 	}
 }

--- a/src/main/java/com/kryptoeuro/accountmapper/service/EthereumService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/EthereumService.java
@@ -77,7 +77,7 @@ public class EthereumService {
 		return send(json("eth_sendRawTransaction", hex(transaction.getEncoded())));
 	}
 
-	private String hex(byte[] bytes) {
+	protected String hex(byte[] bytes) {
 		return with0x(Hex.toHexString(bytes));
 	}
 

--- a/src/main/java/com/kryptoeuro/accountmapper/service/EthereumService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/EthereumService.java
@@ -166,11 +166,11 @@ public class EthereumService {
 		return jsonNode.get("result").asText();
 	}
 
-	private String without0x(String hex) {
+	protected String without0x(String hex) {
 		return hex.startsWith("0x") ? hex.substring(2) : hex;
 	}
 
-	private String with0x(String hex) {
+	protected String with0x(String hex) {
 		return hex.startsWith("0x") ? hex : "0x" + hex;
 	}
 

--- a/src/main/java/com/kryptoeuro/accountmapper/service/LdapService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/LdapService.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.kryptoeuro.accountmapper.error.LdapNotFoundException;
 import com.kryptoeuro.accountmapper.response.LdapResponse;
 import com.kryptoeuro.accountmapper.LdapResponseRepository;
 
@@ -60,15 +61,17 @@ public class LdapService {
 
 			connection.unBind();
 			connection.close();
-
-			if (lResponse != null && lResponse.getIdCode() > 0) {
-				storeLocalCache(lResponse);
-			}
-
 		} catch (Exception e) {
 			log.error("Exception trying LDAP " + e.toString());
 		}
 
-		return lResponse;
+
+		if (lResponse != null && lResponse.getIdCode() > 0) {
+			storeLocalCache(lResponse);
+			return lResponse;
+		} else {
+			return null; 
+		}
+
 	}
 }

--- a/src/main/java/com/kryptoeuro/accountmapper/service/LdapService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/LdapService.java
@@ -46,7 +46,7 @@ public class LdapService {
 		LdapNetworkConnection connection = new LdapNetworkConnection("ldap.sk.ee");
 		try {
 			connection.bind();
-			EntryCursor cursor = connection.search("ou=Authentication,o=ESTEID,c=EE", "(serialNumber="+String.valueOf(idCode)+")", SearchScope.SUBTREE, "*");
+			EntryCursor cursor = connection.search("c=EE", "(serialNumber="+String.valueOf(idCode)+")", SearchScope.SUBTREE, "*");
 
 			while (cursor.next()) {
 				Entry entry = cursor.get();

--- a/src/main/java/com/kryptoeuro/accountmapper/service/WalletServerService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/WalletServerService.java
@@ -5,16 +5,31 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.net.URL;
+import java.net.HttpURLConnection;
+import java.io.OutputStreamWriter;
+import java.util.List;
+import java.util.Arrays;
+import org.json.JSONObject;
+import org.json.JSONException;
+import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import com.kryptoeuro.accountmapper.response.WalletServerAccountResponse;
+import com.kryptoeuro.accountmapper.response.WalletServerHistoryResponse;
 
 @Service
 @Slf4j
 public class WalletServerService {
 
+	@Autowired
+	EthereumService ethService;
+
 	private String walletServer = "http://wallet.euro2.ee:8080"; // wallet-server node on AWS
+	private String refServer = "http://wallet.euro2.ee:8000/"; // wallet-server node on AWS
 
 	public WalletServerAccountResponse getAccount(String address) {
 
@@ -26,5 +41,47 @@ public class WalletServerService {
 			log.error("Failed loading account data from wallet-server", e);
 		}
 		return obj;
+	}
+
+	public List<WalletServerHistoryResponse> getHistory(String address) {
+		
+		ObjectMapper mapper = new ObjectMapper();
+		WalletServerHistoryResponse[] obj = null; 
+		try { 
+			obj = mapper.readValue(new URL(walletServer+"/v1/accounts/"+address+"/transfers"), WalletServerHistoryResponse[].class);
+		
+	  	    for (WalletServerHistoryResponse resp : obj) {
+			log.info("History: tx " + resp.getId() + " from " + resp.getSourceAccount());
+		    }
+		} catch (Exception e) {
+			log.error("Failed loading history data from wallet-server", e);
+		}
+		return Arrays.asList(obj);
+	}
+
+	public void copyReference(String fromTransactionHash, String toTransactionHash) throws MalformedURLException, JSONException {
+
+		try {
+			JSONObject refJson = new JSONObject(IOUtils.toString(new URL(refServer+ethService.without0x(fromTransactionHash)), Charset.forName("UTF-8")));
+
+			  byte[] postDataBytes = refJson.toString().getBytes("UTF-8");
+
+			  URL url = new URL(refServer+ethService.without0x(toTransactionHash));
+			  HttpURLConnection httpCon = (HttpURLConnection) url.openConnection();
+			  httpCon.setRequestMethod("POST");
+		          httpCon.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+		          httpCon.setRequestProperty("Content-Length", String.valueOf(postDataBytes.length));
+			  httpCon.setDoOutput(true);
+       			  httpCon.getOutputStream().write(postDataBytes);
+
+			  OutputStreamWriter out = new OutputStreamWriter(
+			      httpCon.getOutputStream());
+			  log.info("Putting ref: "+httpCon.getResponseCode()+ " msg: " + httpCon.getResponseMessage());
+			  out.close();
+			log.info("got this ref json: " + refJson.toString());
+		} catch (IOException io) {
+			log.warn("IO excpetion in reading reference, probably doesn't exist for tx: "+fromTransactionHash);
+		}
+		
 	}
 }

--- a/src/main/java/com/kryptoeuro/accountmapper/service/WalletServerService.java
+++ b/src/main/java/com/kryptoeuro/accountmapper/service/WalletServerService.java
@@ -1,0 +1,30 @@
+package com.kryptoeuro.accountmapper.service;
+
+import org.springframework.stereotype.Service;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import com.kryptoeuro.accountmapper.response.WalletServerAccountResponse;
+
+@Service
+@Slf4j
+public class WalletServerService {
+
+	private String walletServer = "http://wallet.euro2.ee:8080"; // wallet-server node on AWS
+
+	public WalletServerAccountResponse getAccount(String address) {
+
+		ObjectMapper mapper = new ObjectMapper();
+		WalletServerAccountResponse obj = null; 
+		try { 
+			obj = mapper.readValue(new URL(walletServer+"/v1/accounts/"+address), WalletServerAccountResponse.class);
+		} catch (Exception e) {
+			log.error("Failed loading account data from wallet-server", e);
+		}
+		return obj;
+	}
+}

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -21,3 +21,7 @@ flyway:
     continue-on-error: false
     test-on-borrow: true
     validation-query: SELECT 1
+
+escrow:
+  encryption:
+    password: Change-This-On-Production

--- a/src/main/resources/db/migration/V1_13__persist_escrow.sql
+++ b/src/main/resources/db/migration/V1_13__persist_escrow.sql
@@ -1,0 +1,9 @@
+CREATE TABLE escrow (
+  id BIGINT(20) NOT NULL AUTO_INCREMENT,
+  id_code BIGINT(20) NOT NULL,
+  private_key VARCHAR(250),
+  address VARCHAR(250),
+  cleared boolean,
+  clearing_hash VARCHAR(250),
+  PRIMARY KEY (id)
+);


### PR DESCRIPTION
Objective: send to future members, before they have first approved ethereum address.
Solution:  when asked to send to non-member, the escrow-agent creates a temporary ethereum address  and stores the private key encrypted with their password. When this recipient joins at a future date then the escrow-agent transfers all funds to the new member's address and deactivates the escrow  accounts.
Functional on http://wallet.euro2.ee